### PR TITLE
Updates for the 2026 GraphQL Conf

### DIFF
--- a/ios/GraphQLConf.xcodeproj/project.pbxproj
+++ b/ios/GraphQLConf.xcodeproj/project.pbxproj
@@ -480,7 +480,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 8.4;
+				MARKETING_VERSION = 8.6;
 				PRODUCT_BUNDLE_IDENTIFIER = com.apollographql.GraphQLConf;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -521,7 +521,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 8.4;
+				MARKETING_VERSION = 8.6;
 				PRODUCT_BUNDLE_IDENTIFIER = com.apollographql.GraphQLConf;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";

--- a/ios/GraphQLConf/Extensions/DateFormatter+Shared.swift
+++ b/ios/GraphQLConf/Extensions/DateFormatter+Shared.swift
@@ -2,7 +2,7 @@ import Foundation
 
 extension DateFormatter {
 
-  static var sharedTimezone: TimeZone { TimeZone(identifier: "Europe/Amsterdam")! }
+  static var sharedTimezone: TimeZone { TimeZone(identifier: "America/Los_Angeles")! }
   static var sharedLocale: Locale { Locale(identifier: "en_US") }
 
   static let sharedDateReader: DateFormatter = {

--- a/ios/GraphQLConf/Views/InfoTabView.swift
+++ b/ios/GraphQLConf/Views/InfoTabView.swift
@@ -7,8 +7,8 @@ struct InfoTabView: View {
     case privacyPolicy
     case healthAndSafety
     case inclusionAndAccessibility
-    case eventResources
-    case venueMap
+//    case eventResources
+//    case venueMap
     case graphqlOrg
 
     var title: String {
@@ -17,20 +17,20 @@ struct InfoTabView: View {
       case .privacyPolicy: "Privacy Policy"
       case .healthAndSafety: "Health & Safety"
       case .inclusionAndAccessibility: "Inclusion & Accessibility"
-      case .eventResources: "Event Resources"
-      case .venueMap: "Venue Map"
+//      case .eventResources: "Event Resources"
+//      case .venueMap: "Venue Map"
       case .graphqlOrg: "graphql.org"
       }
     }
 
     var url: URL {
       switch self {
-      case .codeOfConduct: URL(string: "https://graphql.org/conf/2025/resources/#code-of-conduct")!
+      case .codeOfConduct: URL(string: "https://graphql.org/conf/2026/resources/#code-of-conduct")!
       case .privacyPolicy: URL(string: "https://lfprojects.org/policies/privacy-policy/")!
-      case .healthAndSafety: URL(string: "https://graphql.org/conf/2025/resources/#health--safety")!
-      case .inclusionAndAccessibility: URL(string: "https://graphql.org/conf/2025/resources/#inclusion--accessibility")!
-      case .eventResources: URL(string: "http://bit.ly/graphqlconf2025")!
-      case .venueMap: Bundle.main.venueMapURL
+      case .healthAndSafety: URL(string: "https://graphql.org/conf/2026/resources/#health--safety")!
+      case .inclusionAndAccessibility: URL(string: "https://graphql.org/conf/2026/resources/#inclusion--accessibility")!
+//      case .eventResources: URL(string: "http://bit.ly/graphqlconf2026")!
+//      case .venueMap: Bundle.main.venueMapURL
       case .graphqlOrg: URL(string: "https://graphql.org")!
       }
     }
@@ -104,14 +104,14 @@ struct InfoTabView: View {
               .onTapGesture {
                 isInclusionAndAccessibilityPresented.toggle()
               }
-            InfoCellView(title: InfoLink.eventResources.title)
-              .onTapGesture {
-                isEventResourcesPresented.toggle()
-              }
-            InfoCellView(title: InfoLink.venueMap.title)
-              .onTapGesture {
-                isVenueMapPresented.toggle()
-              }
+//            InfoCellView(title: InfoLink.eventResources.title)
+//              .onTapGesture {
+//                isEventResourcesPresented.toggle()
+//              }
+//            InfoCellView(title: InfoLink.venueMap.title)
+//              .onTapGesture {
+//                isVenueMapPresented.toggle()
+//              }
             InfoCellView(title: InfoLink.graphqlOrg.title)
               .onTapGesture {
                 isGraphqlOrgPresented.toggle()
@@ -184,22 +184,22 @@ struct InfoTabView: View {
           .presentationDragIndicator(.visible)
       }
     }
-    .sheet(isPresented: $isEventResourcesPresented) {
-      NavigationStack {
-        WebViewRepresentable(url: InfoLink.eventResources.url)
-          .navigationTitle(InfoLink.eventResources.title)
-          .navigationBarTitleDisplayMode(.inline)
-          .presentationDragIndicator(.visible)
-      }
-    }
-    .sheet(isPresented: $isVenueMapPresented) {
-      NavigationStack {
-        WebViewRepresentable(url: InfoLink.venueMap.url)
-          .navigationTitle(InfoLink.venueMap.title)
-          .navigationBarTitleDisplayMode(.inline)
-          .presentationDragIndicator(.visible)
-      }
-    }
+//    .sheet(isPresented: $isEventResourcesPresented) {
+//      NavigationStack {
+//        WebViewRepresentable(url: InfoLink.eventResources.url)
+//          .navigationTitle(InfoLink.eventResources.title)
+//          .navigationBarTitleDisplayMode(.inline)
+//          .presentationDragIndicator(.visible)
+//      }
+//    }
+//    .sheet(isPresented: $isVenueMapPresented) {
+//      NavigationStack {
+//        WebViewRepresentable(url: InfoLink.venueMap.url)
+//          .navigationTitle(InfoLink.venueMap.title)
+//          .navigationBarTitleDisplayMode(.inline)
+//          .presentationDragIndicator(.visible)
+//      }
+//    }
     .sheet(isPresented: $isGraphqlOrgPresented) {
       NavigationStack {
         WebViewRepresentable(url: InfoLink.graphqlOrg.url)

--- a/ios/GraphQLConf/Views/MainView.swift
+++ b/ios/GraphQLConf/Views/MainView.swift
@@ -37,7 +37,7 @@ struct MainView: View {
       .navigationBarTitleDisplayMode(.inline)
       .toolbar {
         ToolbarItem(placement: .principal) {
-          Text("GraphQLConf 2025")
+          Text("GraphQLConf 2026")
             .foregroundStyle(Theme.tintReverse)
             .font(.HostGrotesk.navigationTitle)
         }


### PR DESCRIPTION
Some changes to push an update for the 2026 GraphQL Conf
- updated date strings to 2026
- removed info items that aren't working right now (event resources, venue map)